### PR TITLE
parse include in ssh config, fix: json provider, signer in executor

### DIFF
--- a/provider/json/provider.go
+++ b/provider/json/provider.go
@@ -68,7 +68,7 @@ func (p *jsonProvider) Load(ctx context.Context, lm herd.LoadingMessage) (herd.H
 
 	var hosts herd.Hosts
 	err = json.Unmarshal(data, &hosts)
-	return nil, err
+	return hosts, err
 }
 
 var _ herd.DataLoader = &jsonProvider{}

--- a/ssh/agent.go
+++ b/ssh/agent.go
@@ -239,8 +239,6 @@ func (a *agent) SignersForPath(path string) []ssh.Signer {
 	if path != "" {
 		if k, ok := a.signersByPath[path]; ok {
 			return []ssh.Signer{k}
-		} else {
-			return []ssh.Signer{}
 		}
 	}
 	return a.signers

--- a/ssh/config_test.go
+++ b/ssh/config_test.go
@@ -1,0 +1,122 @@
+package ssh
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/seveas/herd"
+)
+
+func cpTestdata(name string, destDir string) error {
+	bf, err := ioutil.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		return err
+	}
+	dest := filepath.Join(destDir, name)
+	err = ioutil.WriteFile(dest, bf, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestIncludes(t *testing.T) {
+	testDir, err := os.MkdirTemp(os.TempDir(), "test-includes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(testDir)
+	}()
+
+	configDir := filepath.Join(testDir, "config.d")
+	err = os.Mkdir(configDir, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cpTestdata("include_prod", configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cpTestdata("include_test", configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertConfig := func(t *testing.T, bl []*configBlock) {
+		if len(bl) != 9 {
+			t.Errorf("expected %d blocks, but got %d", 9, len(bl))
+		}
+		c := &config{
+			user: user.User{
+				Username: "bob",
+				HomeDir:  "/home/bob",
+			},
+			blocks: bl,
+		}
+		type tcase struct {
+			host    string
+			expUser string
+			expPort int
+			expId   string
+		}
+		for i, tc := range []*tcase{
+			{host: "", expUser: "bob", expPort: 22, expId: ""},
+			{host: "xyz", expUser: "bob", expPort: 22, expId: ""},
+			{host: "ab8-001.prod.dom", expUser: "srv-prod", expPort: 2022, expId: "/home/bob/.ssh/keys.d/id_key_prod"},
+			{host: "ab8-002.prod.dom", expUser: "srv-prod", expPort: 2022, expId: "/home/bob/.ssh/keys.d/id_key_prod"},
+			{host: "cb8-003.prod.dom", expUser: "srv-prod", expPort: 2022, expId: "/home/bob/.ssh/keys.d/id_key_prod"},
+			{host: "ab8-004.test.dom", expUser: "srv-test", expPort: 2023, expId: "/home/bob/.ssh/keys.d/id_key_test"},
+			{host: "fr5-002.test.dom", expUser: "srv-test", expPort: 2023, expId: "/home/bob/.ssh/keys.d/id_key_test"},
+		} {
+			cb := c.forHost(&herd.Host{
+				Name: tc.host,
+			})
+			if cb.clientConfig.User != tc.expUser {
+				t.Errorf("case %d: expected user %s, but got %s", i, tc.expUser, cb.clientConfig.User)
+			}
+			if cb.port != tc.expPort {
+				t.Errorf("case %d: expected port %d, but got %d", i, tc.expPort, cb.port)
+			}
+			if cb.identityFile != tc.expId {
+				t.Errorf("case %d: expected id %s, but got %s", i, tc.expId, cb.identityFile)
+			}
+		}
+
+	}
+
+	t.Run("multiple", func(t *testing.T) {
+		sconf := fmt.Sprintf("Include %s %s",
+			filepath.Join("config.d", "include_prod"),
+			filepath.Join("config.d", "include_test"))
+		conf := filepath.Join(testDir, "include_multiple")
+		err = ioutil.WriteFile(conf, []byte(sconf), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bl, err := parseConfig(true, testDir, "include_multiple")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertConfig(t, bl)
+	})
+
+	t.Run("simple", func(t *testing.T) {
+		sconf := "Include config.d/*"
+		conf := filepath.Join(testDir, "config")
+		err = ioutil.WriteFile(conf, []byte(sconf), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bl, err := parseConfig(true, testDir, "config")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertConfig(t, bl)
+	})
+}

--- a/ssh/executor.go
+++ b/ssh/executor.go
@@ -113,13 +113,7 @@ func (e *Executor) connect(ctx context.Context, host *herd.Host) (*ssh.Client, e
 	cc.HostKeyCallback = func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		return e.hostKeyCallback(host, key, config)
 	}
-	if config.identityFile != "" && len(e.agent.SignersForPath(config.identityFile)) > 0 {
-		// if we have no signer for the identity file, fall back to agent.signers
-		// since the agent may have been externally configured for this.
-		cc.Auth = []ssh.AuthMethod{ssh.PublicKeysCallback(e.agent.SignersForPathCallback(config.identityFile))}
-	} else {
-		cc.Auth = []ssh.AuthMethod{ssh.PublicKeysCallback(e.agent.Signers)}
-	}
+	cc.Auth = []ssh.AuthMethod{ssh.PublicKeysCallback(e.agent.SignersForPathCallback(config.identityFile))}
 
 	address := host.Address
 	if address == "" {

--- a/ssh/testdata/include_prod
+++ b/ssh/testdata/include_prod
@@ -1,0 +1,18 @@
+### Hosts in the production environment
+
+Host *.prod.dom
+  ForwardAgent yes
+  User srv-prod
+  CertificateFile ~/.ssh/keys.d/id_signed_cert_srv-prod
+  IdentityFile ~/.ssh/keys.d/id_key_prod
+  IdentitiesOnly yes
+  Port 2022
+
+Host ab8-001.prod.dom
+  Hostname 10.1.0.1
+
+Host ab8-002.prod.dom
+  Hostname 10.1.0.2
+
+Host cd8-003.prod.dom
+  Hostname 10.1.0.3

--- a/ssh/testdata/include_test
+++ b/ssh/testdata/include_test
@@ -1,0 +1,14 @@
+### Hosts in the test environment
+
+Host *.test.dom
+  ForwardAgent yes
+  IdentityFile ~/.ssh/keys.d/id_key_test
+  IdentitiesOnly yes
+  User srv-test
+  Port 2023
+
+Host ab8-004.test.dom
+  Hostname 10.1.0.4
+
+Host fr5-002.test.dom
+  Hostname 10.1.0.5


### PR DESCRIPTION
* ssh-config: parse includes
* config: fix setting user: set to default only if not provided by config blocks
* fix json provider (broken at 4c08ffe8)
* fix signers in executor