### PR TITLE
Support ssh ControlMaster sockets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,3 +104,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace golang.org/x/crypto => github.com/seveas/crypto v0.7.1-0.20230319133709-6acef24831f8

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seveas/crypto v0.7.1-0.20230319133709-6acef24831f8 h1:8nkZzxT/kQ93Gs9Z9gacLvsXWAIrHY0rmHVh9Zpzcxw=
+github.com/seveas/crypto v0.7.1-0.20230319133709-6acef24831f8/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 github.com/seveas/readline v0.0.0-20191121174238-faa1e4de0d51 h1:Yhh6DDsv4rtwk/Qvmtbc/I/TNRW10tNTB05jelkqc9A=
 github.com/seveas/readline v0.0.0-20191121174238-faa1e4de0d51/go.mod h1:0l9mgQHUILMldSjGSCw1HttuM5mNpAt1NW8hUJQAtlA=
 github.com/seveas/scattergather v1.2.0 h1:f4/Cq2vdBeBqvAMYkedbjHX0Q6nrlCmQBHMLCJBM00E=
@@ -492,6 +494,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -627,6 +630,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -691,6 +695,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/ssh/executor.go
+++ b/ssh/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"os/user"
 	"strconv"
 	"time"
@@ -109,6 +110,22 @@ func (e *Executor) connect(ctx context.Context, host *herd.Host) (*ssh.Client, e
 		return host.Connection.(*ssh.Client), nil
 	}
 	config := e.config.forHost(host)
+	if config.controlMaster && config.controlPath != "" {
+		s, err := os.Stat(config.controlPath)
+		if err == nil && s.Mode()&os.ModeSocket != 0 {
+			logrus.Debugf("ssh: reusing control socket %s", config.controlPath)
+			conn, err := net.Dial("unix", config.controlPath)
+			if err != nil {
+				return nil, err
+			}
+			client, chans, reqs, err := ssh.NewControlClientConn(conn)
+			if err != nil {
+				return nil, err
+			}
+			return ssh.NewClient(client, chans, reqs), nil
+		}
+	}
+
 	cc := config.clientConfig
 	cc.HostKeyCallback = func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		return e.hostKeyCallback(host, key, config)


### PR DESCRIPTION
Using https://github.com/golang/crypto/pull/205 rebased on top of
x/crypto master, we can now connect using ControlMaster connections.

Won't be merged until that PR is in, as I really don't want to use a
forked x/crypto.
