### PR TITLE
Allow "=" as a configuration entry separator in ssh config

### DIFF
--- a/ssh/config.go
+++ b/ssh/config.go
@@ -96,7 +96,7 @@ func (c *configBlock) updateFromBlock(o *configBlock) {
 }
 
 // Parse an openssh config file
-var splitWhitespace = regexp.MustCompile(`\s`)
+var splitWhitespace = regexp.MustCompile(`(\s|=)`)
 
 func parseConfig(file string) ([]*configBlock, error) {
 	data, err := os.ReadFile(file)


### PR DESCRIPTION
Theoretically this would fix https://github.com/seveas/herd/issues/24 which is oversensitive in reporting openssh configuration issues.