### PR TITLE
More sensible and more dynamic timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ test-build: provider-plugins-source
 
 ABORT ?= --exit-code-from herd --abort-on-container-exit
 test-integration:
-	go mod vendor
 	make -C integration/pki
 	test -e integration/openssh/user.key || ssh-keygen -t ecdsa -f integration/openssh/user.key -N ""
 	docker compose down || true


### PR DESCRIPTION
- All timeouts have been increased
- If _one_ of HostTimeout/Timeout is not set, it's calculated
  dynamically based on the other and the desired parallelism.
