### PR TITLE
Make multiple parallel connections to the ssh agent

### DIFF
--- a/cmd/herd/interactive.go
+++ b/cmd/herd/interactive.go
@@ -37,7 +37,7 @@ func runInteractive(cmd *cobra.Command, args []string) error {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
-	executor, err := ssh.NewExecutor(viper.GetDuration("SshAgentTimeout"), *currentUser.user, false)
+	executor, err := ssh.NewExecutor(viper.GetInt("SshAgentCount"), viper.GetDuration("SshAgentTimeout"), *currentUser.user, false)
 	if err != nil {
 		bail(err.Error())
 	}

--- a/cmd/herd/main.go
+++ b/cmd/herd/main.go
@@ -118,6 +118,7 @@ Providers: %s
 	f.Duration("host-timeout", time.Minute, "Per-host timeout for commands")
 	f.Duration("connect-timeout", 15*time.Second, "Per-host ssh connect timeout")
 	f.Duration("ssh-agent-timeout", time.Second, "SSH agent timeout when checking functionality")
+	f.Int("ssh-agent-count", 50, "Number of parallel connections to the ssh agent")
 	f.IntP("parallel", "p", 0, "Maximum number of hosts to run on in parallel")
 	f.StringP("output", "o", "all", "When to print command output (all at once, per host or per line)")
 	f.Bool("no-pager", false, "Disable the use of the pager")
@@ -163,6 +164,12 @@ func initConfig() {
 	}
 
 	// Check configuration variables
+
+	// Limit concurrent ssh connections to parallelism
+	if viper.GetInt("Parallel") != 0 && viper.GetInt("Parallel") < viper.GetInt("SshAgentCount") {
+		viper.Set("SshAgentCount", viper.GetInt("Parallel"))
+	}
+
 	level, err := logrus.ParseLevel(viper.GetString("LogLevel"))
 	if err != nil {
 		bail("Unknown loglevel: %s. Known loglevels: DEBUG, INFO, NORMAL, WARNING, ERROR", viper.GetString("LogLevel"))

--- a/cmd/herd/ping.go
+++ b/cmd/herd/ping.go
@@ -35,7 +35,7 @@ func runPing(cmd *cobra.Command, args []string) error {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
-	executor, err := ssh.NewPingExecutor(viper.GetDuration("SshAgentTimeout"), *currentUser.user)
+	executor, err := ssh.NewPingExecutor(viper.GetInt("SshAgentCount"), viper.GetDuration("SshAgentTimeout"), *currentUser.user)
 	if err != nil {
 		bail(err.Error())
 	}

--- a/cmd/herd/run.go
+++ b/cmd/herd/run.go
@@ -32,7 +32,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
-	executor, err := ssh.NewExecutor(viper.GetDuration("SshAgentTimeout"), *currentUser.user, true)
+	executor, err := ssh.NewExecutor(viper.GetInt("SshAgentCount"), viper.GetDuration("SshAgentTimeout"), *currentUser.user, true)
 	if err != nil {
 		bail(err.Error())
 	}

--- a/cmd/herd/runscript.go
+++ b/cmd/herd/runscript.go
@@ -46,7 +46,7 @@ func runScript(cmd *cobra.Command, args []string) error {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 
-	executor, err := ssh.NewExecutor(viper.GetDuration("SshAgentTimeout"), *currentUser.user, false)
+	executor, err := ssh.NewExecutor(viper.GetInt("SshAgentCount"), viper.GetDuration("SshAgentTimeout"), *currentUser.user, false)
 	if err != nil {
 		bail(err.Error())
 	}

--- a/ssh/agent.go
+++ b/ssh/agent.go
@@ -1,73 +1,33 @@
 package ssh
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"math"
-	"net"
-	"os"
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	sshagent "golang.org/x/crypto/ssh/agent"
 )
 
 type agent struct {
-	sshAgent            sshagent.ExtendedAgent
-	pipelinedConnection io.ReadWriter
-	waiters             []chan agentResponse
-	lock                sync.Mutex
-	signers             []ssh.Signer
-	signersByPath       map[string]ssh.Signer
+	sshAgent   sshagent.ExtendedAgent
+	connection io.ReadWriter
+	waiters    []chan agentResponse
+	lock       sync.Mutex
 }
 
-func newAgent(pipelineTimeout time.Duration) (*agent, error) {
-	sock, err := agentConnection()
-	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to SSH agent: %s", err)
-	}
+func newAgent(sshAgent sshagent.ExtendedAgent, sock io.ReadWriter) *agent {
 	a := &agent{
-		sshAgent:      sshagent.NewClient(sock),
-		waiters:       make([]chan agentResponse, 0, 64),
-		signersByPath: make(map[string]ssh.Signer),
+		sshAgent:   sshAgent,
+		connection: sock,
+		waiters:    make([]chan agentResponse, 0, 64),
 	}
+	go a.readLoop()
 
-	if _, ok := sock.(*net.UnixConn); ok {
-		// Determine whether we can use the faster pipelined ssh agent protocol
-		a.pipelinedConnection, _ = agentConnection()
-		go a.readLoop()
-		if !a.canDoPipelinedSigning(pipelineTimeout) {
-			a.pipelinedConnection.(*net.UnixConn).Close()
-			a.pipelinedConnection = nil
-			logrus.Warnf("Using slow ssh agent, see https://herd.seveas.net/documentation/ssh_agent.html to fix this")
-		}
-	}
-	a.signers, err = a.Signers()
-	if err != nil {
-		return nil, fmt.Errorf("Unable to retrieve keys from SSH agent: %s", err)
-	}
-	if len(a.signers) == 0 {
-		return nil, fmt.Errorf("No keys found in ssh agent")
-	}
-
-	return a, nil
-}
-
-func agentConnection() (io.ReadWriter, error) {
-	if sockPath, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
-		return net.Dial("unix", sockPath)
-	} else if sock := findPageant(); sock != nil {
-		return sock, nil
-	}
-	if _, ok := os.LookupEnv("SSH_CONNECTION"); ok {
-		return nil, fmt.Errorf("No ssh agent found in environment, make sure your ssh agent is running and forwarded")
-	}
-	return nil, fmt.Errorf("No ssh agent found in environment, make sure your ssh agent is running")
+	return a
 }
 
 type agentResponse struct {
@@ -79,21 +39,15 @@ type agentResponse struct {
 // they are not answered within the specified interval (50ms by default), the
 // ssh agent is too old and suffers from the bug solved in
 // https://github.com/openssh/openssh-portable/pull/183
-func (a *agent) canDoPipelinedSigning(timeout time.Duration) bool {
-	keys, err := a.List()
-	if err != nil || len(keys) == 0 {
-		// This is a lie, but avoids double errors: the next step checks
-		// whether there even are keys and will throw a better error
-		return true
-	}
+func (a *agent) functional(key ssh.PublicKey, timeout time.Duration) bool {
 	tests := 10
 	c := make(chan bool)
 	t := time.NewTicker(timeout)
 	defer t.Stop()
-	for i := 0; i < tests; i++ {
-		go func() { _, err = a.Sign(keys[0], []byte("Test")); c <- (err == nil) }()
+	for range tests {
+		go func() { _, err := a.Sign(key, []byte("Test")); c <- (err == nil) }()
 	}
-	for i := 0; i < tests; i++ {
+	for range tests {
 		select {
 		case v := <-c:
 			if !v {
@@ -127,12 +81,12 @@ func (a *agent) readLoop() {
 
 func (a *agent) readSingleReply() ([]byte, error) {
 	var respSizeBuf [4]byte
-	if _, err := io.ReadFull(a.pipelinedConnection, respSizeBuf[:]); err != nil {
+	if _, err := io.ReadFull(a.connection, respSizeBuf[:]); err != nil {
 		return nil, err
 	}
 	respSize := binary.BigEndian.Uint32(respSizeBuf[:])
 	buf := make([]byte, respSize)
-	if _, err := io.ReadFull(a.pipelinedConnection, buf); err != nil {
+	if _, err := io.ReadFull(a.connection, buf); err != nil {
 		return nil, err
 	}
 	return buf, nil
@@ -149,9 +103,6 @@ type agentSignRequest struct {
 }
 
 func (a *agent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
-	if a.pipelinedConnection == nil {
-		return a.sshAgent.Sign(key, data)
-	}
 	req := ssh.Marshal(agentSignRequest{Key: key.Marshal(), Data: data, Flags: uint32(0)})
 	if len(req) > math.MaxUint32 {
 		return nil, errors.New("ssh agent request too large")
@@ -162,7 +113,7 @@ func (a *agent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
 
 	ch := make(chan agentResponse)
 	a.lock.Lock()
-	_, err := a.pipelinedConnection.Write(msg)
+	_, err := a.connection.Write(msg)
 	if err != nil {
 		a.lock.Unlock()
 		return nil, err
@@ -208,20 +159,7 @@ func (a *agent) Unlock(passphrase []byte) error {
 }
 
 func (a *agent) Signers() ([]ssh.Signer, error) {
-	signers, err := a.sshAgent.Signers()
-	if err != nil {
-		return nil, err
-	}
-	if a.pipelinedConnection == nil {
-		return signers, nil
-	}
-
-	ret := make([]ssh.Signer, len(signers))
-	for i, s := range signers {
-		ret[i] = &signer{a, s.PublicKey()}
-	}
-
-	return ret, nil
+	return a.sshAgent.Signers()
 }
 
 func (a *agent) SignWithFlags(key ssh.PublicKey, data []byte, flags sshagent.SignatureFlags) (*ssh.Signature, error) {
@@ -232,58 +170,4 @@ func (a *agent) Extension(extensionType string, contents []byte) ([]byte, error)
 	return a.sshAgent.Extension(extensionType, contents)
 }
 
-func (a *agent) SignersForPathCallback(path string) func() ([]ssh.Signer, error) {
-	return func() ([]ssh.Signer, error) {
-		signers := a.SignersForPath(path)
-		if len(signers) == 0 {
-			return nil, fmt.Errorf("SSH key %s was not found in the SSH agent", path)
-		}
-		return signers, nil
-	}
-}
-
-func (a *agent) SignersForPath(path string) []ssh.Signer {
-	if path == "" {
-		return a.signers
-	}
-	if k, ok := a.signersByPath[path]; ok {
-		return []ssh.Signer{k}
-	}
-	for _, signer := range a.signers {
-		if signer.PublicKey().(*sshagent.Key).Comment == path {
-			a.signersByPath[path] = signer
-			return []ssh.Signer{signer}
-		}
-	}
-
-	// If we didn't find the key, try again by parsing the public key and matching by key data
-	data, err := os.ReadFile(path + ".pub")
-	if err != nil {
-		return []ssh.Signer{}
-	}
-	key, _, _, _, err := ssh.ParseAuthorizedKey(data) //nolint:dogsled // Can't help it that we don't need the rest
-	if err != nil {
-		return []ssh.Signer{}
-	}
-	mkey := key.Marshal()
-	for _, signer := range a.signers {
-		if bytes.Equal(signer.PublicKey().Marshal(), mkey) {
-			a.signersByPath[path] = signer
-			return []ssh.Signer{signer}
-		}
-	}
-	return []ssh.Signer{}
-}
-
-type signer struct {
-	agent *agent
-	key   ssh.PublicKey
-}
-
-func (s *signer) PublicKey() ssh.PublicKey {
-	return s.key
-}
-
-func (s *signer) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
-	return s.agent.Sign(s.key, data)
-}
+var _ sshagent.ExtendedAgent = &agent{}

--- a/ssh/agent_pool.go
+++ b/ssh/agent_pool.go
@@ -1,0 +1,189 @@
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
+)
+
+type agentPool struct {
+	lock          sync.Mutex
+	agents        []sshagent.ExtendedAgent
+	signers       []ssh.Signer
+	signersByPath map[string][]ssh.Signer
+	current       int
+}
+
+func newAgentPool(agentCount int, agentTimeout time.Duration) (*agentPool, error) {
+	sock, err := agentConnection()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to connect to SSH agent: %s", err)
+	}
+	a := sshagent.NewClient(sock)
+	signers, err := a.Signers()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to retrieve keys from SSH agent: %s", err)
+	}
+	if len(signers) == 0 {
+		return nil, fmt.Errorf("No keys found in ssh agent")
+	}
+	sock, _ = agentConnection()
+	pa := newAgent(a, sock)
+
+	pool := &agentPool{
+		agents:        make([]sshagent.ExtendedAgent, agentCount),
+		signers:       make([]ssh.Signer, len(signers)),
+		signersByPath: make(map[string][]ssh.Signer),
+	}
+	for i, s := range signers {
+		pool.signers[i] = &signer{pool, s.PublicKey()}
+	}
+
+	if pa.functional(signers[0].PublicKey(), agentTimeout) {
+		pool.agents[0] = pa
+		for i := 1; i < agentCount; i++ {
+			sock, _ = agentConnection()
+			pool.agents[i] = newAgent(a, sock)
+		}
+	} else {
+		logrus.Warn("SSH agent is too old, falling back to non-pipelined requests")
+		pool.agents[0] = a
+		for i := 1; i < agentCount; i++ {
+			sock, _ = agentConnection()
+			pool.agents[i] = sshagent.NewClient(sock)
+		}
+	}
+	return pool, nil
+}
+
+func (ap *agentPool) nextAgent() sshagent.ExtendedAgent {
+	ap.lock.Lock()
+	defer func() {
+		ap.current = (ap.current + 1) % len(ap.agents)
+		ap.lock.Unlock()
+	}()
+	return ap.agents[ap.current]
+}
+
+func (ap *agentPool) List() ([]*sshagent.Key, error) {
+	return ap.nextAgent().List()
+}
+
+func (ap *agentPool) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
+	return ap.nextAgent().Sign(key, data)
+}
+
+func (ap *agentPool) SignWithFlags(key ssh.PublicKey, data []byte, flags sshagent.SignatureFlags) (*ssh.Signature, error) {
+	return ap.nextAgent().SignWithFlags(key, data, flags)
+}
+
+func (ap *agentPool) Extension(extensionType string, contents []byte) ([]byte, error) {
+	return ap.nextAgent().Extension(extensionType, contents)
+}
+
+func (ap *agentPool) Add(key sshagent.AddedKey) error {
+	return ap.nextAgent().Add(key)
+}
+
+func (ap *agentPool) Remove(key ssh.PublicKey) error {
+	return ap.nextAgent().Remove(key)
+}
+
+func (ap *agentPool) RemoveAll() error {
+	return ap.nextAgent().RemoveAll()
+}
+
+func (ap *agentPool) Lock(passphrase []byte) error {
+	return ap.nextAgent().Lock(passphrase)
+}
+
+func (ap *agentPool) Unlock(passphrase []byte) error {
+	return ap.nextAgent().Unlock(passphrase)
+}
+
+func (ap *agentPool) Signers() ([]ssh.Signer, error) {
+	return ap.signers, nil
+}
+
+func (ap *agentPool) SignersForPathCallback(path string) func() ([]ssh.Signer, error) {
+	return func() ([]ssh.Signer, error) {
+		signers := ap.SignersForPath(path)
+		if len(signers) == 0 {
+			return nil, fmt.Errorf("SSH key %s was not found in the SSH agent", path)
+		}
+		return signers, nil
+	}
+}
+
+func (ap *agentPool) SignersForPath(path string) []ssh.Signer {
+	if path == "" {
+		return ap.signers
+	}
+	if k, ok := ap.signersByPath[path]; ok {
+		return k
+	}
+	ap.lock.Lock()
+	defer ap.lock.Unlock()
+	for _, signer := range ap.signers {
+		if signer.PublicKey().(*sshagent.Key).Comment == path {
+			ap.signersByPath[path] = []ssh.Signer{signer}
+			return []ssh.Signer{signer}
+		}
+	}
+
+	// If we didn't find the key, try again by parsing the public key and matching by key data
+	ap.signersByPath[path] = []ssh.Signer{}
+	data, err := os.ReadFile(path + ".pub")
+	if err != nil {
+		return []ssh.Signer{}
+	}
+	key, _, _, _, err := ssh.ParseAuthorizedKey(data) //nolint:dogsled // Can't help it that we don't need the rest
+	if err != nil {
+		return []ssh.Signer{}
+	}
+	mkey := key.Marshal()
+	for _, signer := range ap.signers {
+		if bytes.Equal(signer.PublicKey().Marshal(), mkey) {
+			ap.signersByPath[path] = []ssh.Signer{signer}
+			return []ssh.Signer{signer}
+		}
+	}
+	return []ssh.Signer{}
+}
+
+func agentConnection() (io.ReadWriter, error) {
+	if sockPath, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
+		return net.Dial("unix", sockPath)
+	} else if sock := findPageant(); sock != nil {
+		return sock, nil
+	}
+	if _, ok := os.LookupEnv("SSH_CONNECTION"); ok {
+		return nil, fmt.Errorf("No ssh agent found in environment, make sure your ssh agent is running and forwarded")
+	}
+	return nil, fmt.Errorf("No ssh agent found in environment, make sure your ssh agent is running")
+}
+
+var _ sshagent.ExtendedAgent = &agentPool{}
+
+type signer struct {
+	agent sshagent.ExtendedAgent
+	key   ssh.PublicKey
+}
+
+func (s *signer) PublicKey() ssh.PublicKey {
+	return s.key
+}
+
+func (s *signer) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return s.agent.Sign(s.key, data)
+}
+
+var _ ssh.Signer = &signer{}

--- a/ssh/executor.go
+++ b/ssh/executor.go
@@ -16,14 +16,14 @@ import (
 )
 
 type Executor struct {
-	agent          *agent
+	agent          *agentPool
 	config         *config
 	connectTimeout time.Duration
 	disconnect     bool
 }
 
-func NewExecutor(agentTimeout time.Duration, user user.User, disconnect bool) (herd.Executor, error) {
-	agent, err := newAgent(agentTimeout)
+func NewExecutor(agentCount int, agentTimeout time.Duration, user user.User, disconnect bool) (herd.Executor, error) {
+	agent, err := newAgentPool(agentCount, agentTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/ssh/ping.go
+++ b/ssh/ping.go
@@ -13,8 +13,8 @@ type PingExecutor struct {
 	Executor
 }
 
-func NewPingExecutor(agentTimeout time.Duration, user user.User) (herd.Executor, error) {
-	executor, err := NewExecutor(agentTimeout, user, true)
+func NewPingExecutor(agentCount int, agentTimeout time.Duration, user user.User) (herd.Executor, error) {
+	executor, err := NewExecutor(agentCount, agentTimeout, user, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We already sped up ssh agent traffic by pipelining it, but especially on
forwarded connections this was not enough. So let's make more than one
connection. We default to 50 (or less if parallelism is less).
