### PR TITLE
Make herd themeable

### DIFF
--- a/cmd/herd/main.go
+++ b/cmd/herd/main.go
@@ -193,7 +193,25 @@ func bail(format string, args ...interface{}) {
 func setupScriptEngine(executor herd.Executor) (*scripting.ScriptEngine, error) {
 	hosts := new(herd.HostSet)
 	hosts.SetSortFields(viper.GetStringSlice("Sort"))
-	ui := herd.NewSimpleUI(hosts)
+	colors := viper.Sub("Colors")
+	colorConfig := herd.ColorConfig{}
+	if colors != nil {
+		colorConfig.LogDebug = colors.GetString("LogDebug")
+		colorConfig.LogInfo = colors.GetString("LogInfo")
+		colorConfig.LogWarn = colors.GetString("LogWarn")
+		colorConfig.LogError = colors.GetString("LogError")
+		colorConfig.Command = colors.GetString("Command")
+		colorConfig.Summary = colors.GetString("Summary")
+		colorConfig.Provider = colors.GetString("Provider")
+		colorConfig.HostStdout = colors.GetString("HostStdout")
+		colorConfig.HostStderr = colors.GetString("HostStderr")
+		colorConfig.HostOK = colors.GetString("HostOK")
+		colorConfig.HostFail = colors.GetString("HostFail")
+		colorConfig.HostError = colors.GetString("HostError")
+		colorConfig.HostCancel = colors.GetString("HostCancel")
+	}
+
+	ui := herd.NewSimpleUI(colorConfig, hosts)
 	ui.SetOutputMode(viper.Get("Output").(herd.OutputMode))
 	ui.SetOutputTimestamp(viper.GetBool("Timestamp"))
 	ui.SetPagerEnabled(!viper.GetBool("NoPager"))

--- a/doc/content/documentation/configuration_reference.md
+++ b/doc/content/documentation/configuration_reference.md
@@ -82,6 +82,29 @@ corresponds to the `--host-timeout` environment variable.
 | `Sort`            | List of strings | How to sort hosts before showing their results, not used for `tail` and `per-host` output                                             |
 | `Timestamp`       | Boolean         | Show a timestamp in front of command output in tail mode                                                                              |
 
+# Theming
+
+All colors used by herd can be customized with a `Colors` section in the configuration. The colors
+it understands are the standard ansi colors with some attributes. For a full specification, see
+https://github.com/mgutz/ansi
+
+```yaml
+Colors:
+  LogDebug:   black+h
+  LogInfo:    default
+  LogWarn:    yellow
+  LogError:   red+b
+  Command:    cyan
+  Summary:    black+h
+  Provider:   green
+  HostStdout: default
+  HostStderr: yellow
+  HostOK:     green
+  HostFail:   yellow
+  HostError:  red
+  HostCancel: black+h
+```
+
 # Other environment variables
 
 - Herd will automatically start a pager when its output spans more than one screen. This defaults to `less`, but can be overridden with the `PAGER` environment variable.

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -5,19 +5,11 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 var results []*Result
 
-var testformatter = prettyFormatter{
-	colors: map[logrus.Level]string{
-		logrus.WarnLevel:  "yellow",
-		logrus.ErrorLevel: "red+b",
-		logrus.DebugLevel: "black+h",
-	},
-}
+var testformatter = newPrettyFormatter(defaultColorConfigDark)
 
 func init() {
 	i := 0
@@ -55,7 +47,7 @@ func init() {
 		},
 		{
 			Host:        fmt.Sprintf("test-host-%03d.example.com", count()),
-			Err:         fmt.Errorf("Process exited with status 1"),
+			Err:         fmt.Errorf("exited with status 1"),
 			ExitStatus:  1,
 			Stdout:      []byte{},
 			Stderr:      []byte("Text on stderr\nMore text\n"),
@@ -65,7 +57,7 @@ func init() {
 		},
 		{
 			Host:        fmt.Sprintf("test-host-%03d.example.com", count()),
-			Err:         fmt.Errorf("Process exited with status 1"),
+			Err:         fmt.Errorf("exited with status 1"),
 			ExitStatus:  1,
 			Stdout:      []byte("Text on stdout\n"),
 			Stderr:      []byte("Text on stderr\nMore text\n"),
@@ -95,8 +87,8 @@ func TestPrettyFormatterFormatStatus(t *testing.T) {
 		"\033[0;31mtest-host-001.example.com  It's always DNS after 12s\033[0m\n",
 		"\033[0;32mtest-host-002.example.com  completed successfully after 12s\033[0m\n",
 		"\033[0;32mtest-host-003.example.com  completed successfully after 12s\033[0m\n",
-		"\033[0;31mtest-host-004.example.com  Process exited with status 1 after 12s\033[0m\n",
-		"\033[0;31mtest-host-005.example.com  Process exited with status 1 after 12s\033[0m\n",
+		"\033[0;33mtest-host-004.example.com  exited with status 1 after 12s\033[0m\n",
+		"\033[0;33mtest-host-005.example.com  exited with status 1 after 12s\033[0m\n",
 		"\033[0;32mtest-host-006.example.com  completed successfully after 12s\033[0m\n",
 	}
 	for i, r := range results {
@@ -111,9 +103,9 @@ func TestPrettyFormatterFormatOutput(t *testing.T) {
 		"\033[0;31mtest-host-001.example.com  It's always DNS after 12s\033[0m\n",
 		"\033[0;32mtest-host-002.example.com  \033[0mMay the forks be with you\n  And you\n",
 		"\033[0;32mtest-host-003.example.com  \033[0mNewline is added automatically\n",
-		"\033[0;31mtest-host-004.example.com  \033[0mText on stderr\n  More text\n\033[0;31mtest-host-004.example.com  Process exited with status 1 after 12s\033[0m\n",
-		"\033[0;31mtest-host-005.example.com  \033[0mText on stdout\n\033[0;31mtest-host-005.example.com  \033[0mText on stderr\n  More text\n\033[0;31mtest-host-005.example.com  Process exited with status 1 after 12s\033[0m\n",
-		"\033[0;32mtest-host-006.example.com  \033[0mText on stdout without newline\n\x1b[0;31mtest-host-006.example.com  \x1b[0mText on stderr\n  More text\n",
+		"\033[0;33mtest-host-004.example.com  \033[0mText on stderr\n  More text\n\033[0;33mtest-host-004.example.com  exited with status 1 after 12s\033[0m\n",
+		"\033[0;33mtest-host-005.example.com  \033[0mText on stdout\n\033[0;33mtest-host-005.example.com  \033[0mText on stderr\n  More text\n\033[0;33mtest-host-005.example.com  exited with status 1 after 12s\033[0m\n",
+		"\033[0;32mtest-host-006.example.com  \033[0mText on stdout without newline\n\x1b[0;33mtest-host-006.example.com  \x1b[0mText on stderr\n  More text\n",
 	}
 	for i, r := range results {
 		if s := testformatter.formatOutput(r, 0); s != expected[i] {
@@ -127,8 +119,8 @@ func TestPrettyFormatterFormatResult(t *testing.T) {
 		"\033[0;31mtest-host-001.example.com  It's always DNS after 12s\033[0m\n",
 		"\033[0;32mtest-host-002.example.com  completed successfully after 12s\033[0m\n    May the forks be with you\n    And you\n",
 		"\033[0;32mtest-host-003.example.com  completed successfully after 12s\033[0m\n    Newline is added automatically\n",
-		"\033[0;31mtest-host-004.example.com  Process exited with status 1 after 12s\033[0m\n\033[0;90m----\033[0m\n    Text on stderr\n    More text\n",
-		"\033[0;31mtest-host-005.example.com  Process exited with status 1 after 12s\033[0m\n    Text on stdout\n\033[0;90m----\033[0m\n    Text on stderr\n    More text\n",
+		"\033[0;33mtest-host-004.example.com  exited with status 1 after 12s\033[0m\n\033[0;90m----\033[0m\n    Text on stderr\n    More text\n",
+		"\033[0;33mtest-host-005.example.com  exited with status 1 after 12s\033[0m\n    Text on stdout\n\033[0;90m----\033[0m\n    Text on stderr\n    More text\n",
 		"\033[0;32mtest-host-006.example.com  completed successfully after 12s\x1b[0m\n    Text on stdout without newline\n\x1b[0;90m----\x1b[0m\n    Text on stderr\n    More text\n",
 	}
 	for i, r := range results {


### PR DESCRIPTION
This started as just wanting to give hosts that ran the command but
exited with non-zero status, and hosts that never ran the command
because the timeout expired, a different color than the hosts where
connecting failed with an error.

But rather than adding yet another hardcoded color, the colors can now
be set in the config. A default theme mathing the existing output is
included.
