### PR TITLE
Allow history to be used as input

### DIFF
--- a/cmd/herd/interactive.go
+++ b/cmd/herd/interactive.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"time"
 
 	"github.com/seveas/herd/scripting"
 	"github.com/seveas/herd/ssh"
@@ -50,12 +49,12 @@ func runInteractive(cmd *cobra.Command, args []string) error {
 		logrus.Error(err.Error())
 		return err
 	}
-	fn := filepath.Join(currentUser.historyDir, time.Now().Format("2006-01-02_150405.json"))
 	engine.Execute()
 
 	// Enter interactive mode
 	il := &interactiveLoop{engine: engine}
 	il.run()
+	fn := historyFile(currentUser.historyDir)
 	return engine.History.Save(fn)
 }
 

--- a/cmd/herd/run.go
+++ b/cmd/herd/run.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
-	"time"
 
 	"github.com/seveas/herd/ssh"
 
@@ -45,7 +43,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		logrus.Error(err.Error())
 		return err
 	}
-	fn := filepath.Join(currentUser.historyDir, time.Now().Format("2006-01-02_150405.json"))
 	engine.Execute()
+	fn := historyFile(currentUser.historyDir)
 	return engine.History.Save(fn)
 }

--- a/cmd/herd/runscript.go
+++ b/cmd/herd/runscript.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
-	"time"
 
 	"github.com/seveas/herd/ssh"
 
@@ -63,7 +61,7 @@ func runScript(cmd *cobra.Command, args []string) error {
 		logrus.Errorf("Unable to parse script %s: %s", args[0], err)
 		return err
 	}
-	fn := filepath.Join(currentUser.historyDir, time.Now().Format("2006-01-02_150405.json"))
 	engine.Execute()
+	fn := historyFile(currentUser.historyDir)
 	return engine.History.Save(fn)
 }

--- a/doc/content/documentation/host_query.md
+++ b/doc/content/documentation/host_query.md
@@ -39,6 +39,19 @@ A special type of glob-like match is when the name starts with `file:`. This loa
 from a file. Because no matter how powerful the queries are that you learn later on in this file,
 sometimes you just have a list of hosts to work on.
 
+Another special glob prefix is `hist:`. This will load the list of hosts from the output of a
+command from your history, and adds attributes to the hosts that correspond to the last result. This
+lets you easily retry commands on hosts where they failed before.
+
+```console
+$ herd run hist:-1 exitstatus!=0 -- /usr/bin/command-to-retry
+```
+
+Where `file:` needs a relative or absolute path to a file, `hist:` needs a number that is either
+negative to specify the n-last command or positive to specify a specific history item. This number
+corresponds to the prefix of the history file in your history, which you see as the last line inf
+the output of a `herd run` command.
+
 ## Multiple sets of hosts
 
 You can also specify multiple sets of hosts this way:
@@ -99,7 +112,8 @@ You can also filter for inequality or do regular expression matches on attribute
 | `!~`         | Regular expression does not match | `availability_zone!~us`       |
 
 Combined with set arithmetic, this can lead to queries that really give you only the hosts you are
-looking for.
+looking for. Attribute matching also works with the `file:` and `hist:` pseudo-globs. This makes it
+possible to do something like easily retrying a command.
 
 ### Attribute types
 
@@ -127,16 +141,16 @@ different meaning
 Host attributes come from the host providers you use, but there are also some built-in attributes
 that are always available:
 
-| Attribute       | Type            | Meaning                                                                                                                  |
-|-----------------|-----------------|--------------------------------------------------------------------------------------------------------------------------|
-| `name`          | String          | The name of the host                                                                                                     |
-| `domainname`    | String          | The domainname of the host                                                                                               |
-| `random`        | Integer         | A not-really-random number for stable not-really-random sorting                                                          |
-| `stdout`        | String          | The output of the last command in interactive/scripted mode                                                              |
-| `stderr`        | String          | The output of the last command in interactive/scripted mode                                                              |
-| `exitstatus`    | Integer         | The exit status of the last command in interactive/scripted mode, `-1` when there wan error establishing a connection    |
-| `err`           | Error           | The error that occurred during the last command in interactive/scripted mode. Note that a non-zero exit is also an error |
-| `herd_provider` | List of strings | The name(s) of the provider(s) that found information about this host                                                    |
+| Attribute       | Type            | Meaning                                                                                                                                           |
+|-----------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`          | String          | The name of the host                                                                                                                              |
+| `domainname`    | String          | The domainname of the host                                                                                                                        |
+| `random`        | Integer         | A not-really-random number for stable not-really-random sorting                                                                                   |
+| `stdout`        | String          | The output of the last command in interactive/scripted mode or when using `hist:` globs                                                           |
+| `stderr`        | String          | The output of the last command in interactive/scripted mode or when using `hist:` globs                                                           |
+| `exitstatus`    | Integer         | The exit status of the last command in interactive/scripted mode or when using `hist:` globs, `-1` when there wan error establishing a connection |
+| `err`           | Error           | The error that occurred during the last command in interactive/scripted mode. Note that a non-zero exit is also an error                          |
+| `herd_provider` | List of strings | The name(s) of the provider(s) that found information about this host                                                                             |
 
 ## Sampling
 

--- a/host.go
+++ b/host.go
@@ -34,8 +34,8 @@ type Host struct {
 	Address    string
 	Attributes HostAttributes
 	Connection io.Closer
+	LastResult *Result
 	publicKeys []ssh.PublicKey
-	lastResult *Result
 	csum       uint32
 }
 
@@ -154,7 +154,7 @@ func (h *Host) GetAttribute(key string) (interface{}, bool) {
 	if ok {
 		return value, ok
 	}
-	r := h.lastResult
+	r := h.LastResult
 	if r == nil {
 		r = &Result{ExitStatus: -1}
 	}

--- a/hostset.go
+++ b/hostset.go
@@ -54,6 +54,16 @@ func (s *HostSet) Search(hostnameGlob string, attributes MatchAttributes) *HostS
 	return &HostSet{hosts: hosts, maxNameLength: maxNameLength(hosts)}
 }
 
+func (s *HostSet) Filter(f func(*Host) bool) *HostSet {
+	hosts := make([]*Host, 0)
+	for _, host := range s.hosts {
+		if f(host) {
+			hosts = append(hosts, host)
+		}
+	}
+	return &HostSet{hosts: hosts, maxNameLength: maxNameLength(hosts)}
+}
+
 func (s *HostSet) AddHost(host *Host) {
 	s.hosts = append(s.hosts, host)
 	if l := len(host.Name); l > s.maxNameLength {

--- a/runner.go
+++ b/runner.go
@@ -151,7 +151,7 @@ func (r *Runner) Run(command string, pc chan ProgressMessage, oc chan OutputLine
 			defer cancel()
 			result := r.executor.Run(ctx, host, command, oc)
 			result.index = index
-			host.lastResult = result
+			host.LastResult = result
 			pc <- ProgressMessage{Host: host, State: Finished, Result: result}
 			return result, nil
 		})
@@ -198,7 +198,7 @@ func (r *Runner) Run(command string, pc chan ProgressMessage, oc chan OutputLine
 	for index, host := range r.hosts.hosts {
 		if hi.Results[index] == nil {
 			result := &Result{Host: host.Name, ExitStatus: -1, Err: errors.New("context canceled")}
-			host.lastResult = result
+			host.LastResult = result
 			pc <- ProgressMessage{Host: host, State: Finished, Result: result}
 			hi.Results[index] = result
 			hi.Summary.Err++
@@ -209,7 +209,7 @@ func (r *Runner) Run(command string, pc chan ProgressMessage, oc chan OutputLine
 			// We re-sort hosts and results according to the result of the last command
 			r.hosts.Sort()
 			for idx, host := range r.hosts.hosts {
-				host.lastResult.index = idx
+				host.LastResult.index = idx
 			}
 			sort.Slice(hi.Results, func(i, j int) bool { return hi.Results[i].index < hi.Results[j].index })
 			break

--- a/scripting/commands.go
+++ b/scripting/commands.go
@@ -66,9 +66,6 @@ type addHostsCommand struct {
 
 func (c addHostsCommand) execute(e *ScriptEngine) {
 	hosts := e.Registry.Search(c.glob, c.attributes, c.sampled, c.count)
-	if strings.HasPrefix(c.glob, "file:") {
-		e.Hosts.SetSortFields([]string{})
-	}
 	e.Hosts.AddHosts(hosts)
 }
 


### PR DESCRIPTION
To make it easy to e.g. retry commands or query results of commands, history files can now be used similar to how `file:` pseudoglobs are used. To accomplish this, a few changes need to be made:
    
- `file:` pseudoglob handling is made more generic, a hook is added to register such prefixes
- The cli registers such a prefix for `hist:`
- When such a psudoglob is used, a history file is read and used for filtering
- To be able to query results of last commands, LastResult is made public so the filter can set it
- The (un)marshaling of history items is fixed to not use maps but to use proper objects
- History file names now have a sequential number
