### PR TITLE
file: pseudoglobs should make sure we contact all hosts in the file

### DIFF
--- a/integration/t0003_list.t
+++ b/integration/t0003_list.t
@@ -9,4 +9,10 @@ test_expect_success "List all hosts when not specifying anything" "
     grep t0003.example.com out
 "
 
+test_expect_success "When using file:, list all hosts in the file" "
+	echo t0003-bis.example.com >file &&
+	herd -l debug list file:file >out &&
+	grep t0003-bis.example.com out
+"
+
 test_done


### PR DESCRIPTION
The recent rewrite broke this, and it is now fixed, with added test.
