### PR TITLE
Fix (and test) glob prefix / sampling parsing

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -298,6 +298,14 @@ func (r *Registry) AddGlobPrefix(prefix string, fnc func(string, *HostSet) (*Hos
 	r.globPrefixes[prefix] = fnc
 }
 
+func (r *Registry) GlobPrefixes() []string {
+	ret := make([]string, 0, len(r.globPrefixes))
+	for k := range r.globPrefixes {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
 func fileFilter(fn string, hs *HostSet) (*HostSet, error) {
 	seen := make(map[string]bool)
 	file, err := os.Open(fn)

--- a/scripting/engine_test.go
+++ b/scripting/engine_test.go
@@ -118,11 +118,17 @@ func TestParseCommandLine(t *testing.T) {
 			cmd:  []command{},
 			err:  "only one sampling per hostspec allowed",
 		},
+		{
+			spec: []string{"file:1"},
+			cmd:  []command{addHostsCommand{glob: "file:1", attributes: herd.MatchAttributes{}, sampled: []string{}}},
+			err:  "",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(strings.Join(test.spec, " "), func(t *testing.T) {
-			e := NewScriptEngine(nil, nil, nil, nil)
+			r := herd.NewRegistry("", "")
+			e := NewScriptEngine(nil, nil, r, nil)
 			err := e.ParseCommandLine(test.spec, -1)
 			if (err != nil && err.Error() != test.err) || (err == nil && test.err != "") {
 				t.Errorf("Unexpected error %v, expected %v", err, test.err)
@@ -134,7 +140,7 @@ func TestParseCommandLine(t *testing.T) {
 				return
 			}
 			test.spec = append(test.spec, "id", "seveas")
-			e = NewScriptEngine(nil, nil, nil, nil)
+			e = NewScriptEngine(nil, nil, r, nil)
 			err = e.ParseCommandLine(test.spec, len(test.spec)-2)
 			if (err != nil && err.Error() != test.err) || (err == nil && test.err != "") {
 				t.Errorf("Unexpected error %v, expected %v", err, test.err)


### PR DESCRIPTION
There's a syntax conflict between sampling and glob prefix syntax. This
solves it in favor of glob prefixes.
