### PR TITLE
De-magic the known hosts provider.

### DIFF
--- a/host.go
+++ b/host.go
@@ -124,8 +124,7 @@ func (h Host) String() string {
 	return fmt.Sprintf("Host{Name: %s, Keys: %d, Attributes: %s}", h.Name, len(h.publicKeys), h.Attributes)
 }
 
-// Adds a public key to a host. Used by the ssh know hosts provider, but can be
-// used by any other code as well.
+// Adds a public key to a host, it will be used by the SSH client when connecting
 func (h *Host) AddPublicKey(k ssh.PublicKey) {
 	h.publicKeys = append(h.publicKeys, k)
 }

--- a/integration/t1001_hostkeys.t
+++ b/integration/t1001_hostkeys.t
@@ -12,14 +12,29 @@ test_expect_success "We can scan SSH keys" "
 for keytype in rsa ecdsa ed25519; do
     test_expect_success "We can connect to an $keytype host" "
         cp ~/.ssh/known_hosts_prime ~/.ssh/known_hosts &&
-        herd run ssh-$keytype.example.com -- uptime | grep load
-    "
-
-    test_expect_success "We can connect to a host with all keys when we have just an $keytype key" "
-        grep $keytype ~/.ssh/known_hosts_prime > ~/.ssh/known_hosts &&
-        herd run ssh.example.com -- uptime | grep load
+        herd run ssh-$keytype.example.com -- 'uptime | grep load'
     "
 done
 
+for keytype in rsa ecdsa; do
+    test_expect_failure "We can not connect to a host with all keys when we have just an $keytype key" "
+        grep $keytype ~/.ssh/known_hosts_prime > ~/.ssh/known_hosts &&
+        herd run ssh.example.com -- 'uptime | grep load'
+    "
+done
+
+keytype=ed25519
+test_expect_success "We can connect to a host with all keys when we have just an $keytype key" "
+    grep $keytype ~/.ssh/known_hosts_prime > ~/.ssh/known_hosts &&
+    herd run ssh.example.com -- 'uptime | grep load'
+"
+
+: > .ssh/config
+for keytype in rsa ecdsa ed25519; do
+    test_expect_success "We can connect to a host with all keys when we have just an $keytype key" "
+        grep $keytype ~/.ssh/known_hosts_prime > ~/.ssh/known_hosts &&
+        herd run ssh.example.com -- 'uptime | grep load'
+    "
+done
 
 test_done

--- a/integration/t2001_consul.t
+++ b/integration/t2001_consul.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description="HTTP provider"
+test_description="Consul provider"
 
 . ./sharness.sh
 

--- a/provider/known_hosts/provider.go
+++ b/provider/known_hosts/provider.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	herd.RegisterProvider("known_hosts", newProvider, magicProvider)
+	herd.RegisterProvider("known_hosts", newProvider, nil)
 }
 
 type knownHostsProvider struct {

--- a/ssh/config.go
+++ b/ssh/config.go
@@ -73,6 +73,22 @@ func newConfigBlock(globs []string) *configBlock {
 		clientConfig: &ssh.ClientConfig{
 			ClientVersion: clientVersion,
 			Timeout:       3 * time.Second,
+			HostKeyAlgorithms: []string{
+				// We make this match openssh's default host key algorithms minus the sk- variants
+				ssh.CertAlgoED25519v01,
+				ssh.CertAlgoECDSA256v01,
+				ssh.CertAlgoECDSA384v01,
+				ssh.CertAlgoECDSA521v01,
+				ssh.CertAlgoRSASHA512v01,
+				ssh.CertAlgoRSASHA256v01,
+				ssh.KeyAlgoED25519,
+				ssh.KeyAlgoECDSA256,
+				ssh.KeyAlgoECDSA384,
+				ssh.KeyAlgoECDSA521,
+				ssh.KeyAlgoRSASHA512,
+				ssh.KeyAlgoRSASHA256,
+				ssh.KeyAlgoRSA,
+			},
 		},
 	}
 }


### PR DESCRIPTION
known_hosts accumulates cruft, so it's not quite suitable as a default
provider. It can still be enabled manually if one likes, but won't be
enabled magically.

To keep the functionality of checking host keys intact, we re-implement
host key checking using the `ssh.knownhosts` package.
