### PR TITLE
Support wildcards in `--attributes=*` arguments

### DIFF
--- a/cmd/herd/list.go
+++ b/cmd/herd/list.go
@@ -22,8 +22,8 @@ func init() {
 	f := listCmd.Flags()
 	f.Bool("oneline", false, "List all hosts on one line, separated by commas")
 	f.String("separator", ",", "String separating hostnames in --oneline mode")
-	f.StringSlice("attributes", []string{}, "Show not only the names, but also the specified attributes")
-	f.Bool("all-attributes", false, "List hosts with all their attributes")
+	f.Bool("all-attributes", false, "List hosts with all their attributes (deprecated, use --attributes=* instead)")
+	f.StringSlice("attributes", []string{}, "Show not only the names, but also the specified attributes (supports wildcards)")
 	f.Bool("csv", false, "Output in csv format")
 	f.Bool("header", true, "Print attribute names in a header line before printing host data")
 	f.String("template", "", "Template to use for showing hosts")
@@ -55,20 +55,22 @@ func runList(cmd *cobra.Command, args []string) error {
 		logrus.Error(err.Error())
 		return err
 	}
+	// Backwards compatibility code
+	if viper.GetBool("all-attributes") {
+		viper.Set("attributes", []string{"*"})
+	}
 	engine.Execute()
 	opts := herd.HostListOptions{
-		OneLine:       viper.GetBool("OneLine"),
-		Separator:     viper.GetString("Separator"),
-		Csv:           viper.GetBool("csv"),
-		Attributes:    viper.GetStringSlice("Attributes"),
-		AllAttributes: viper.GetBool("AllAttributes"),
-		Header:        viper.GetBool("Header"),
-		Align:         true,
-		Template:      viper.GetString("Template"),
-		Count:         viper.GetStringSlice("Count"),
-		CountAll:      len(viper.GetStringSlice("Count")) == 1 && viper.GetStringSlice("Count")[0] == "*",
-		SortByCount:   !viper.IsSet("Sort"),
-		Group:         viper.GetString("Group"),
+		OneLine:     viper.GetBool("OneLine"),
+		Separator:   viper.GetString("Separator"),
+		Csv:         viper.GetBool("csv"),
+		Attributes:  viper.GetStringSlice("Attributes"),
+		Header:      viper.GetBool("Header"),
+		Align:       true,
+		Template:    viper.GetString("Template"),
+		Count:       viper.GetStringSlice("Count"),
+		SortByCount: !viper.IsSet("Sort"),
+		Group:       viper.GetString("Group"),
 	}
 	engine.Ui.PrintHostList(opts)
 	return nil

--- a/integration/t0003_list.t
+++ b/integration/t0003_list.t
@@ -5,7 +5,7 @@ test_description="Test the list command"
 . ./sharness.sh
 
 test_expect_success "List all hosts when not specifying anything" "
-    herd -l debug list >out &&
+    herd list >out &&
     grep t0003.example.com out
 "
 
@@ -13,6 +13,13 @@ test_expect_success "When using file:, list all hosts in the file" "
 	echo t0003-bis.example.com >file &&
 	herd -l debug list file:file >out &&
 	grep t0003-bis.example.com out
+"
+
+test_expect_success "It supports wildcard attributes" "
+    herd list --attributes key* >out 2>&1 &&
+    grep t0003.example.com out &&
+    grep key:1 out &&
+    grep key:2 out
 "
 
 test_done

--- a/integration/t0003_list/herd/config.yaml
+++ b/integration/t0003_list/herd/config.yaml
@@ -3,3 +3,6 @@ Providers:
   plain:
     provider: plain
     file: plain.txt
+  json:
+    provider: json
+    file: multi.json

--- a/integration/t0003_list/herd/multi.json
+++ b/integration/t0003_list/herd/multi.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "t0003.example.com",
+        "attributes": {
+            "key:1": "value:1",
+            "key:2": "value:2"
+        }
+    }
+]


### PR DESCRIPTION
This deprecates `--all-attributes`, but we keep it for now.
