### PR TITLE
Trim trailing newlines in columnwriter

### DIFF
--- a/datawriter.go
+++ b/datawriter.go
@@ -27,6 +27,9 @@ func (c *columnizer) Write(r []string) error {
 	if c.lengths == nil {
 		c.lengths = make([]int, len(r))
 	}
+	for i := range r {
+		r[i] = strings.TrimRight(r[i], "\r\n")
+	}
 	c.rows = append(c.rows, r)
 	tl := len(c.lengths) - 1
 	for i, v := range r {


### PR DESCRIPTION
This makes using `stdout` in `herd list` a tad more usable. Still can't
use it with multiline output, but that's for another day.
