### PR TITLE
Don't show execution progress with warning/error loglevel

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -770,6 +770,9 @@ func (ui *SimpleUI) OutputChannel() chan OutputLine {
 }
 
 func (ui *SimpleUI) ProgressChannel(deadline time.Time) chan ProgressMessage {
+	if !logrus.IsLevelEnabled(logrus.InfoLevel) {
+		return nil
+	}
 	pc := make(chan ProgressMessage)
 	go func() {
 		start := time.Now()


### PR DESCRIPTION
We already don't show loading progress, it makes sense to not show
execution progress either.
